### PR TITLE
Use node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ inputs:
     description: 'Secret token used to contact Trello'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Node 12 is not in use anymore, see https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/